### PR TITLE
Add optional HTTP bridge and WordPress plugin proxy for AI generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # wp-mcp
-MCP tool for create, edit and get posts from your Wordpress website. 
+MCP server for create, edit and delete posts in your WordPress website, with optional AI-generated drafts.
+
+## Quick start
+1. Install dependencies and build:
+   ```bash
+   npm install
+   npm run build
+   ```
+
+2. Configure environment variables:
+   ```bash
+   export WORDPRESS_URL="https://example.com"
+   export WORDPRESS_USER="admin"
+   export WORDPRESS_APP_PASSWORD="xxxx xxxx xxxx xxxx"
+   ```
+
+3. Run the MCP server:
+   ```bash
+   npm start
+   ```
+
+## Tools
+- `create_post`: Creates a post in WordPress.
+- `update_post`: Updates a post.
+- `delete_post`: Deletes a post.
+- `generate_post`: Generates a draft using the configured AI provider.
+
+## HTTP bridge (optional)
+If you want a WordPress plugin or external system to call the AI generator over HTTP, set `HTTP_PORT`.
+
+```bash
+export HTTP_PORT=8080
+npm start
+```
+
+Endpoints:
+- `GET /health`
+- `POST /generate`
+
+## WordPress plugin (optional)
+The `wp-plugin/wp-mcp-bridge` folder contains a small plugin that calls the HTTP bridge. Install it
+inside `wp-content/plugins` and configure the bridge URL in WordPress settings.
+
+## AI provider integration
+The server ships with a `NullAIProvider` that just echoes data. Replace it by injecting an `AIProvider`
+implementation and passing it to `startServer` in `src/index.ts`.
+
+## Notes
+- Requires WordPress REST API access and an application password.
+- App passwords are stored only in environment variables.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "wp-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for managing WordPress posts with optional AI content generation.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "wp-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node --esm src/index.ts",
+    "lint": "eslint . --ext .ts"
+  },
+  "keywords": [
+    "mcp",
+    "wordpress",
+    "ai"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "eslint": "^9.15.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/src/ai/null-provider.ts
+++ b/src/ai/null-provider.ts
@@ -1,0 +1,11 @@
+import type { AIProvider, GeneratePostInput, GeneratedPost } from "./provider.js";
+
+export class NullAIProvider implements AIProvider {
+  async generatePost(input: GeneratePostInput): Promise<GeneratedPost> {
+    return {
+      title: input.title,
+      content: input.outline ?? "",
+      excerpt: input.keywords?.join(", "),
+    };
+  }
+}

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -1,0 +1,16 @@
+export type GeneratePostInput = {
+  title: string;
+  outline?: string;
+  keywords?: string[];
+  language?: string;
+};
+
+export type GeneratedPost = {
+  title: string;
+  content: string;
+  excerpt?: string;
+};
+
+export interface AIProvider {
+  generatePost(input: GeneratePostInput): Promise<GeneratedPost>;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const configSchema = z.object({
+  wordpressUrl: z.string().url(),
+  wordpressUser: z.string().min(1),
+  wordpressAppPassword: z.string().min(1),
+  aiProvider: z.string().optional(),
+  httpPort: z.coerce.number().int().positive().optional(),
+});
+
+export type AppConfig = z.infer<typeof configSchema>;
+
+export const loadConfig = (): AppConfig => {
+  const config = {
+    wordpressUrl: process.env.WORDPRESS_URL,
+    wordpressUser: process.env.WORDPRESS_USER,
+    wordpressAppPassword: process.env.WORDPRESS_APP_PASSWORD,
+    aiProvider: process.env.AI_PROVIDER,
+    httpPort: process.env.HTTP_PORT,
+  };
+
+  return configSchema.parse(config);
+};

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,0 +1,64 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { z } from "zod";
+
+import type { AIProvider } from "../ai/provider.js";
+
+const generatePostSchema = z.object({
+  title: z.string().min(1),
+  outline: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  language: z.string().optional(),
+});
+
+export type HttpServerOptions = {
+  port: number;
+  aiProvider: AIProvider;
+};
+
+const readJsonBody = async (req: IncomingMessage): Promise<unknown> => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  if (chunks.length === 0) {
+    return {};
+  }
+  const raw = Buffer.concat(chunks).toString("utf-8");
+  return JSON.parse(raw);
+};
+
+const sendJson = (res: ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body, null, 2));
+};
+
+export const startHttpServer = ({ port, aiProvider }: HttpServerOptions): void => {
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (req.method === "GET" && req.url === "/health") {
+        sendJson(res, 200, { status: "ok" });
+        return;
+      }
+
+      if (req.method === "POST" && req.url === "/generate") {
+        const payload = await readJsonBody(req);
+        const input = generatePostSchema.parse(payload);
+        const generated = await aiProvider.generatePost(input);
+        sendJson(res, 200, generated);
+        return;
+      }
+
+      sendJson(res, 404, { error: "Not found" });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        sendJson(res, 400, { error: "Invalid request", details: error.errors });
+        return;
+      }
+      sendJson(res, 500, { error: "Server error" });
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`HTTP bridge listening on :${port}`);
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,16 @@
+import { NullAIProvider } from "./ai/null-provider.js";
+import { loadConfig } from "./config.js";
+import { startHttpServer } from "./http/server.js";
+import { startServer } from "./mcp/server.js";
+
+const config = loadConfig();
+const provider = new NullAIProvider();
+
+startServer({ config, aiProvider: provider }).catch((error) => {
+  console.error("Failed to start wp-mcp server:", error);
+  process.exitCode = 1;
+});
+
+if (config.httpPort) {
+  startHttpServer({ port: config.httpPort, aiProvider: provider });
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,131 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import type { AIProvider } from "../ai/provider.js";
+import { NullAIProvider } from "../ai/null-provider.js";
+import type { AppConfig } from "../config.js";
+import { WordPressClient } from "../wordpress/client.js";
+
+const createPostSchema = z.object({
+  title: z.string().min(1),
+  content: z.string().min(1),
+  excerpt: z.string().optional(),
+  status: z.enum(["draft", "publish", "private", "future"]).optional(),
+});
+
+const updatePostSchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  excerpt: z.string().optional(),
+  status: z.enum(["draft", "publish", "private", "future"]).optional(),
+});
+
+const deletePostSchema = z.object({
+  id: z.number().int().positive(),
+  force: z.boolean().optional(),
+});
+
+const generatePostSchema = z.object({
+  title: z.string().min(1),
+  outline: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  language: z.string().optional(),
+});
+
+export type MCPServerOptions = {
+  config: AppConfig;
+  aiProvider?: AIProvider;
+};
+
+export const startServer = async ({ config, aiProvider }: MCPServerOptions): Promise<void> => {
+  const client = new WordPressClient(
+    config.wordpressUrl,
+    config.wordpressUser,
+    config.wordpressAppPassword,
+  );
+  const provider = aiProvider ?? new NullAIProvider();
+
+  const server = new Server(
+    { name: "wp-mcp", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler("tools/list", async () => ({
+    tools: [
+      {
+        name: "create_post",
+        description: "Create a WordPress post.",
+        inputSchema: createPostSchema,
+      },
+      {
+        name: "update_post",
+        description: "Update a WordPress post.",
+        inputSchema: updatePostSchema,
+      },
+      {
+        name: "delete_post",
+        description: "Delete a WordPress post.",
+        inputSchema: deletePostSchema,
+      },
+      {
+        name: "generate_post",
+        description: "Generate a post draft using the configured AI provider.",
+        inputSchema: generatePostSchema,
+      },
+    ],
+  }));
+
+  server.setRequestHandler("tools/call", async (request) => {
+    const { name, arguments: args } = request.params;
+
+    switch (name) {
+      case "create_post": {
+        const input = createPostSchema.parse(args ?? {});
+        const result = await client.createPost(input);
+        return {
+          content: [{
+            type: "text",
+            text: `Post created: ${result.id} (${result.title.rendered})`,
+          }],
+        };
+      }
+      case "update_post": {
+        const input = updatePostSchema.parse(args ?? {});
+        const result = await client.updatePost(input);
+        return {
+          content: [{
+            type: "text",
+            text: `Post updated: ${result.id} (${result.title.rendered})`,
+          }],
+        };
+      }
+      case "delete_post": {
+        const input = deletePostSchema.parse(args ?? {});
+        const result = await client.deletePost(input.id, input.force ?? false);
+        return {
+          content: [{
+            type: "text",
+            text: `Post deleted: ${result.previous.id} (${result.previous.title.rendered})`,
+          }],
+        };
+      }
+      case "generate_post": {
+        const input = generatePostSchema.parse(args ?? {});
+        const generated = await provider.generatePost(input);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(generated, null, 2),
+          }],
+        };
+      }
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+};

--- a/src/wordpress/client.ts
+++ b/src/wordpress/client.ts
@@ -1,0 +1,67 @@
+export type PostInput = {
+  title: string;
+  content: string;
+  excerpt?: string;
+  status?: "draft" | "publish" | "private" | "future";
+};
+
+export type PostUpdate = Partial<PostInput> & { id: number };
+
+export type PostResponse = {
+  id: number;
+  link: string;
+  status: string;
+  title: { rendered: string };
+};
+
+export class WordPressClient {
+  private readonly baseUrl: string;
+  private readonly authHeader: string;
+
+  constructor(baseUrl: string, username: string, appPassword: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+    const token = Buffer.from(`${username}:${appPassword}`).toString("base64");
+    this.authHeader = `Basic ${token}`;
+  }
+
+  async createPost(input: PostInput): Promise<PostResponse> {
+    return this.request<PostResponse>("/wp-json/wp/v2/posts", {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  }
+
+  async updatePost(input: PostUpdate): Promise<PostResponse> {
+    const { id, ...rest } = input;
+    return this.request<PostResponse>(`/wp-json/wp/v2/posts/${id}`, {
+      method: "POST",
+      body: JSON.stringify(rest),
+    });
+  }
+
+  async deletePost(id: number, force = false): Promise<{ deleted: boolean; previous: PostResponse }> {
+    const query = new URLSearchParams({ force: String(force) }).toString();
+    return this.request<{ deleted: boolean; previous: PostResponse }>(
+      `/wp-json/wp/v2/posts/${id}?${query}`,
+      { method: "DELETE" },
+    );
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.authHeader,
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`WordPress API error (${response.status}): ${errorText}`);
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/wp-plugin/wp-mcp-bridge/README.md
+++ b/wp-plugin/wp-mcp-bridge/README.md
@@ -1,0 +1,23 @@
+# WP MCP Bridge
+
+This WordPress plugin exposes a REST endpoint that proxies AI generation requests to the MCP HTTP bridge.
+
+## Install
+1. Copy `wp-mcp-bridge` into your WordPress `wp-content/plugins` directory.
+2. Activate **WP MCP Bridge** in the WordPress admin.
+3. Go to **Settings → WP MCP Bridge** and set the MCP bridge URL.
+
+## REST endpoint
+`POST /wp-json/wp-mcp/v1/generate`
+
+Payload:
+```json
+{
+  "title": "Example",
+  "outline": "Optional outline",
+  "keywords": ["ai", "wordpress"],
+  "language": "sv"
+}
+```
+
+The endpoint requires `edit_posts` capability.

--- a/wp-plugin/wp-mcp-bridge/wp-mcp-bridge.php
+++ b/wp-plugin/wp-mcp-bridge/wp-mcp-bridge.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Plugin Name: WP MCP Bridge
+ * Description: Connects WordPress to an external MCP HTTP bridge for AI content generation.
+ * Version: 0.1.0
+ * Author: wp-mcp
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+const WP_MCP_OPTION_URL = 'wp_mcp_bridge_url';
+
+function wp_mcp_register_settings() {
+    register_setting('wp_mcp_settings', WP_MCP_OPTION_URL, [
+        'type' => 'string',
+        'sanitize_callback' => 'esc_url_raw',
+        'default' => '',
+    ]);
+
+    add_settings_section('wp_mcp_main', 'MCP Bridge', '__return_false', 'wp_mcp_settings');
+
+    add_settings_field(
+        'wp_mcp_bridge_url',
+        'MCP Bridge URL',
+        'wp_mcp_bridge_url_field',
+        'wp_mcp_settings',
+        'wp_mcp_main'
+    );
+}
+add_action('admin_init', 'wp_mcp_register_settings');
+
+function wp_mcp_bridge_url_field() {
+    $value = esc_url(get_option(WP_MCP_OPTION_URL));
+    echo '<input type="url" name="' . esc_attr(WP_MCP_OPTION_URL) . '" value="' . esc_attr($value) . '" class="regular-text" placeholder="https://mcp.example.com" />';
+}
+
+function wp_mcp_register_menu() {
+    add_options_page('WP MCP Bridge', 'WP MCP Bridge', 'manage_options', 'wp-mcp-bridge', 'wp_mcp_render_settings');
+}
+add_action('admin_menu', 'wp_mcp_register_menu');
+
+function wp_mcp_render_settings() {
+    ?>
+    <div class="wrap">
+        <h1>WP MCP Bridge</h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields('wp_mcp_settings');
+            do_settings_sections('wp_mcp_settings');
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}
+
+function wp_mcp_register_routes() {
+    register_rest_route('wp-mcp/v1', '/generate', [
+        'methods' => 'POST',
+        'callback' => 'wp_mcp_generate_post',
+        'permission_callback' => function () {
+            return current_user_can('edit_posts');
+        },
+    ]);
+}
+add_action('rest_api_init', 'wp_mcp_register_routes');
+
+function wp_mcp_generate_post(WP_REST_Request $request) {
+    $bridge_url = get_option(WP_MCP_OPTION_URL);
+    if (!$bridge_url) {
+        return new WP_REST_Response(['error' => 'Bridge URL not configured'], 400);
+    }
+
+    $payload = [
+        'title' => sanitize_text_field($request->get_param('title')),
+        'outline' => sanitize_textarea_field($request->get_param('outline')),
+        'keywords' => array_map('sanitize_text_field', (array) $request->get_param('keywords')),
+        'language' => sanitize_text_field($request->get_param('language')),
+    ];
+
+    $response = wp_remote_post(rtrim($bridge_url, '/') . '/generate', [
+        'headers' => ['Content-Type' => 'application/json'],
+        'body' => wp_json_encode($payload),
+        'timeout' => 15,
+    ]);
+
+    if (is_wp_error($response)) {
+        return new WP_REST_Response(['error' => $response->get_error_message()], 502);
+    }
+
+    $status = wp_remote_retrieve_response_code($response);
+    $body = json_decode(wp_remote_retrieve_body($response), true);
+
+    return new WP_REST_Response($body, $status ?: 200);
+}


### PR DESCRIPTION
### Motivation
- Provide an HTTP bridge so external systems (for example a WordPress plugin) can request AI-generated post drafts over a simple REST API.  
- Expose a minimal, pluggable AI provider integration so the same provider can be used by the MCP server and the HTTP bridge.  
- Offer a ready-to-install WordPress plugin that proxies `/wp-json/.../generate` requests to the HTTP bridge to enable in-WordPress generation workflows.  

### Description
- Add an HTTP bridge implementation at `src/http/server.ts` with `GET /health` and `POST /generate` and a `startHttpServer` entry.  
- Wire configuration and startup in `src/index.ts` to load `src/config.ts` and start the MCP server plus an optional HTTP bridge using the `NullAIProvider`.  
- Introduce AI provider types and a `NullAIProvider` (`src/ai/provider.ts`, `src/ai/null-provider.ts`) and a `WordPressClient` for REST operations (`src/wordpress/client.ts`).  
- Add a minimal WordPress plugin skeleton under `wp-plugin/wp-mcp-bridge` that registers a settings page and a REST endpoint which proxies generation requests to the HTTP bridge.  

### Testing
- No automated tests were executed as part of this change.  
- No CI or unit tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69525731710483269b0bf206a0aeb172)